### PR TITLE
FAQ: Question Popularity

### DIFF
--- a/src/app/code/community/Flagbit/Faq/Block/Adminhtml/Category/Grid.php
+++ b/src/app/code/community/Flagbit/Faq/Block/Adminhtml/Category/Grid.php
@@ -55,6 +55,14 @@ class Flagbit_Faq_Block_Adminhtml_Category_Grid extends Mage_Adminhtml_Block_Wid
                 'type' => 'text', 
                 'index' => 'category_id' ));
         
+        $this->addColumn(
+            'category_name',
+            array(
+                'header' => Mage::helper('flagbit_faq')->__('Category Name'), 
+                'index' => 'category_name',
+            )
+        );
+
         if (!Mage::app()->isSingleStoreMode()) {
             $this->addColumn('store_id',
                     array (
@@ -68,14 +76,6 @@ class Flagbit_Faq_Block_Adminhtml_Category_Grid extends Mage_Adminhtml_Block_Wid
                                     $this, 
                                     '_filterStoreCondition' ) ));
         }
-        
-        $this->addColumn(
-            'category_name',
-            array(
-                'header' => Mage::helper('flagbit_faq')->__('Category Name'), 
-                'index' => 'category_name',
-            )
-        );
         
         $this->addColumn('is_active', 
                 array (

--- a/src/app/code/community/Flagbit/Faq/Block/Adminhtml/Item/Grid.php
+++ b/src/app/code/community/Flagbit/Faq/Block/Adminhtml/Item/Grid.php
@@ -57,6 +57,10 @@ class Flagbit_Faq_Block_Adminhtml_Item_Grid extends Mage_Adminhtml_Block_Widget_
                 'type' => 'text', 
                 'index' => 'faq_id' ));
         
+        $this->addColumn('question', array (
+                'header' => Mage::helper('flagbit_faq')->__('Question'), 
+                'index' => 'question' ));
+        
         if (!Mage::app()->isSingleStoreMode()) {
             $this->addColumn('store_id', 
                     array (
@@ -70,10 +74,6 @@ class Flagbit_Faq_Block_Adminhtml_Item_Grid extends Mage_Adminhtml_Block_Widget_
                                     $this, 
                                     '_filterStoreCondition' ) ));
         }
-        
-        $this->addColumn('question', array (
-                'header' => Mage::helper('flagbit_faq')->__('Question'), 
-                'index' => 'question' ));
         
         $this->addColumn('is_active', 
                 array (

--- a/src/app/code/community/Flagbit/Faq/Block/Frontend/List.php
+++ b/src/app/code/community/Flagbit/Faq/Block/Frontend/List.php
@@ -129,6 +129,20 @@ class Flagbit_Faq_Block_Frontend_List extends Mage_Core_Block_Template
 		return count($this->getFaqJumplist()) > 0;
 	}
 	
+	public function getPopularQuestions($limit = 10, $page = 1)
+	{
+		$collection = Mage::getModel('flagbit_faq/faq')
+			->getCollection()
+			->setPageSize($limit)
+			->setCurPage($page);
+
+		// Order by popularity. For more information on why this is necessary 
+		// instead of setOrder() or addAttributeToSort() see http://goo.gl/Jeq3h
+		$collection->getSelect()->order("popularity DESC");
+
+		return $collection;
+	}
+
 	public function encodeQuestionForUrl($question)
 	{
 		return 	urlencode(

--- a/src/app/code/community/Flagbit/Faq/Block/Frontend/List.php
+++ b/src/app/code/community/Flagbit/Faq/Block/Frontend/List.php
@@ -129,6 +129,14 @@ class Flagbit_Faq_Block_Frontend_List extends Mage_Core_Block_Template
 		return count($this->getFaqJumplist()) > 0;
 	}
 	
+	/**
+	 * Lists our FAQ items (individual questions) by popularity. This allows you 
+	 * to show the most popular questions on the FAQ index page.
+	 *
+	 * @var  int  Number of items to show per page (SQL LIMIT).
+	 * @var  int  Number of the page to display, paired with $limit
+	 * @return Flagbit_Faq_Model_Mysql_Faq_Collection collection of current FAQ entries
+	 */
 	public function getPopularQuestions($limit = 10, $page = 1)
 	{
 		$collection = Mage::getModel('flagbit_faq/faq')

--- a/src/app/code/community/Flagbit/Faq/controllers/IndexController.php
+++ b/src/app/code/community/Flagbit/Faq/controllers/IndexController.php
@@ -69,7 +69,8 @@ class Flagbit_Faq_IndexController extends Mage_Core_Controller_Front_Action
 			return;
 		}
 
-		$faq->setPopularity($faq->getPopularity() + 1)
-		    ->save();
+		$table = Mage::getSingleton('core/resource')->getTableName('faq');
+		$db    = Mage::getSingleton('core/resource')->getConnection('core/write');
+		$db->query("UPDATE `$table` SET `popularity` = `popularity` + 1 WHERE `faq_id` = :id", array(":id" => (int) $id));
 	}
 }

--- a/src/app/code/community/Flagbit/Faq/controllers/IndexController.php
+++ b/src/app/code/community/Flagbit/Faq/controllers/IndexController.php
@@ -65,6 +65,8 @@ class Flagbit_Faq_IndexController extends Mage_Core_Controller_Front_Action
 			{
 				$this->_forward('defaultNoRoute');
 			}
+
+			return;
 		}
 
 		$faq->setPopularity($faq->getPopularity() + 1)

--- a/src/app/code/community/Flagbit/Faq/etc/config.xml
+++ b/src/app/code/community/Flagbit/Faq/etc/config.xml
@@ -4,7 +4,7 @@
 		<Flagbit_Faq>
 			<active>true</active>
 			<codePool>community</codePool>
-			<version>1.1.2</version>
+			<version>1.1.4</version>
 		</Flagbit_Faq>
 	</modules>
 	

--- a/src/app/code/community/Flagbit/Faq/sql/faq_setup/mysql4-install-1.1.4.php
+++ b/src/app/code/community/Flagbit/Faq/sql/faq_setup/mysql4-install-1.1.4.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * FAQ for Magento
+ *
+ * @category   Flagbit
+ * @package    Flagbit_Faq
+ * @copyright  Copyright (c) 2009 Flagbit GmbH & Co. KG <magento@flagbit.de>
+ */
+
+$installer = $this;
+
+$installer->startSetup();
+
+$installer->run("
+-- DROP TABLE IF EXISTS {$this->getTable('flagbit_faq/faq')};
+CREATE TABLE IF NOT EXISTS {$this->getTable('flagbit_faq/faq')} (
+  `faq_id` int(10) unsigned NOT NULL auto_increment,
+  `question` tinytext NOT NULL default '',
+  `answer` text NOT NULL default '',
+  `answer_html` tinyint(1) NOT NULL default '1',
+  `creation_time` datetime NOT NULL,
+  `update_time` datetime NOT NULL,
+  `is_active` tinyint(1) NOT NULL default '1',
+  `popularity` int(10) NOT NULL default '0',
+  PRIMARY KEY  (`faq_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='FAQ items' AUTO_INCREMENT=1 ;
+
+-- DROP TABLE IF EXISTS `{$this->getTable('flagbit_faq/faq_store')}`;
+CREATE TABLE `{$this->getTable('flagbit_faq/faq_store')}` (
+  `faq_id` int(10) unsigned NOT NULL,
+  `store_id` smallint(5) unsigned NOT NULL,
+  PRIMARY KEY (`faq_id`,`store_id`),
+  CONSTRAINT `FK_FAQ_FAQ_STORE_FAQ` FOREIGN KEY (`faq_id`) REFERENCES `{$this->getTable('flagbit_faq/faq')}` (`faq_id`) ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT `FK_FAQ_FAQ_STORE_STORE` FOREIGN KEY (`store_id`) REFERENCES `{$this->getTable('core/store')}` (`store_id`) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='FAQ items to Stores';
+
+CREATE TABLE `{$this->getTable('flagbit_faq/category')}` (
+    `category_id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `parent_id` INT(10) UNSIGNED NULL,
+    `category_name` VARCHAR(255) NOT NULL,
+    `creation_time` DATETIME NOT NULL,
+    `update_time` DATETIME NOT NULL,
+    `is_active` TINYINT(1) NOT NULL DEFAULT 1,
+    PRIMARY KEY (`category_id`),
+    CONSTRAINT `FK_FAQ_CATEGORY_PARENT_ID` FOREIGN KEY (`parent_id`) REFERENCES `{$this->getTable('flagbit_faq/category')}` (`category_id`) ON DELETE SET NULL
+) ENGINE=InnoDB COMMENT='FAQ Categories';
+
+-- DROP TABLE IF EXISTS `{$this->getTable('flagbit_faq/category_item')}`;
+CREATE TABLE `{$this->getTable('flagbit_faq/category_item')}` (
+  `category_id` INT(10) UNSIGNED NOT NULL,
+  `faq_id` INT(10) UNSIGNED NOT NULL,
+  PRIMARY KEY (`category_id`,`faq_id`),
+  CONSTRAINT `FK_FAQ_CATEGORY_ITEM_CATEGORY` FOREIGN KEY (`category_id`) REFERENCES `{$this->getTable('flagbit_faq/category')}` (`category_id`) ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT `FK_FAQ_CATEGORY_ITEM_ITEM` FOREIGN KEY (`faq_id`) REFERENCES `{$this->getTable('flagbit_faq/faq')}` (`faq_id`) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB COMMENT='FAQ Items to Cateories';
+
+-- DROP TABLE IF EXISTS `{$this->getTable('flagbit_faq/category_store')}`;
+CREATE TABLE `{$this->getTable('flagbit_faq/category_store')}` (
+  `category_id` INT(10) UNSIGNED NOT NULL,
+  `store_id` SMALLINT(5) UNSIGNED NOT NULL,
+  PRIMARY KEY (`category_id`,`store_id`),
+  CONSTRAINT `FK_FAQ_CATEGORY_STORE_CATEGORY` FOREIGN KEY (`category_id`) REFERENCES `{$this->getTable('flagbit_faq/category')}` (`category_id`) ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT `FK_FAQ_CATEGORY_STORE_STORE` FOREIGN KEY (`store_id`) REFERENCES `{$this->getTable('core/store')}` (`store_id`) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB COMMENT='FAQ Categories to Stores';
+
+");
+
+$installer->endSetup();

--- a/src/app/code/community/Flagbit/Faq/sql/faq_setup/mysql4-upgrade-1.0.7-1.1.4.php
+++ b/src/app/code/community/Flagbit/Faq/sql/faq_setup/mysql4-upgrade-1.0.7-1.1.4.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * FAQ for Magento
+ *
+ * @category   Flagbit
+ * @package    Flagbit_Faq
+ * @copyright  Copyright (c) 2009 Flagbit GmbH & Co. KG <magento@flagbit.de>
+ */
+
+$installer = $this;
+
+$installer->startSetup();
+
+$installer->run("
+
+ALTER TABLE `{$this->getTable('flagbit_faq/faq')}`
+    ADD COLUMN `popularity` int(10) NOT NULL DEFAULT '0'
+
+");
+
+$installer->endSetup();


### PR DESCRIPTION
Hi Flagbit, 

I've just added a small feature to the FAQ Magento which tracks questions by popularity.

The idea is that you can show questions in a jQuery accordion and each time a question is clicked on we bump that question's popularity.

This allows us to show the most popular questions on the FAQ index page, ultimately increasing usability and decreasing the number of clicks.

Could we integrate this into Master, please?

Thanks,
Tony
